### PR TITLE
Implement full CRUD API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,14 @@ curl -X POST http://localhost:8000/v1/task_recon \
 curl http://localhost:8000/v1/cases
 ```
 
-These endpoints provide a basic demonstration and can be expanded with persistent storage, authentication, additional sensors or a frontend for visualization.
+### 5. List all events
+```bash
+curl http://localhost:8000/v1/events
+```
+
+### 6. List all recon tasks
+```bash
+curl http://localhost:8000/v1/task_recon
+```
+
+These endpoints provide a basic demonstration and can be expanded with persistent storage, authentication, additional sensors or a frontend for visualization. Each collection supports standard CRUD operations (create, read, update and delete) for events, cases and tasks.

--- a/backend/app/routers/cases.py
+++ b/backend/app/routers/cases.py
@@ -17,6 +17,33 @@ def create_case(case: Case):
 def list_cases():
     return cases_db
 
+@router.get("/{case_id}", response_model=Case)
+def read_case(case_id: str):
+    case = get_case(case_id)
+    if not case:
+        raise HTTPException(status_code=404, detail="case not found")
+    return case
+
+@router.put("/{case_id}", response_model=Case)
+def update_case(case_id: str, case_update: Case):
+    if not get_event(case_update.initial_event_id):
+        raise HTTPException(status_code=404, detail="initial_event_id not found")
+    case = get_case(case_id)
+    if not case:
+        raise HTTPException(status_code=404, detail="case not found")
+    case_update.id = case_id
+    idx = cases_db.index(case)
+    cases_db[idx] = case_update
+    return case_update
+
+@router.delete("/{case_id}")
+def delete_case(case_id: str):
+    case = get_case(case_id)
+    if not case:
+        raise HTTPException(status_code=404, detail="case not found")
+    cases_db.remove(case)
+    return {"detail": "deleted"}
+
 def get_case(case_id: str) -> Case:
     for c in cases_db:
         if c.id == case_id:

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from ..models import Event
 
 router = APIRouter(prefix="/v1/events", tags=["events"])
@@ -9,6 +9,35 @@ events_db = []
 def create_event(event: Event):
     events_db.append(event)
     return event
+
+@router.get("", response_model=list[Event])
+def list_events():
+    return events_db
+
+@router.get("/{event_id}", response_model=Event)
+def read_event(event_id: str):
+    event = get_event(event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="event not found")
+    return event
+
+@router.put("/{event_id}", response_model=Event)
+def update_event(event_id: str, event_update: Event):
+    event = get_event(event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="event not found")
+    event_update.id = event_id
+    idx = events_db.index(event)
+    events_db[idx] = event_update
+    return event_update
+
+@router.delete("/{event_id}")
+def delete_event(event_id: str):
+    event = get_event(event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="event not found")
+    events_db.remove(event)
+    return {"detail": "deleted"}
 
 def get_event(event_id: str) -> Event:
     for e in events_db:

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -18,3 +18,40 @@ def create_task(task_req: TaskRequest):
     )
     tasks_db.append(task)
     return task
+
+@router.get("", response_model=list[Task])
+def list_tasks():
+    return tasks_db
+
+def get_task(task_id: str) -> Task:
+    for t in tasks_db:
+        if t.id == task_id:
+            return t
+    return None
+
+@router.get("/{task_id}", response_model=Task)
+def read_task(task_id: str):
+    task = get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="task not found")
+    return task
+
+@router.put("/{task_id}", response_model=Task)
+def update_task(task_id: str, update: Task):
+    if not get_case(update.case_id):
+        raise HTTPException(status_code=404, detail="case_id not found")
+    task = get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="task not found")
+    update.id = task_id
+    idx = tasks_db.index(task)
+    tasks_db[idx] = update
+    return update
+
+@router.delete("/{task_id}")
+def delete_task(task_id: str):
+    task = get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="task not found")
+    tasks_db.remove(task)
+    return {"detail": "deleted"}


### PR DESCRIPTION
## Summary
- add list, get, update and delete routes for events
- expand cases API with standard CRUD endpoints
- flesh out tasks API with CRUD support
- document new operations in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uvicorn backend.app.main:app --port 8001` *(started then stopped)*


------
https://chatgpt.com/codex/tasks/task_e_688572785cb0832eac4cfd6e54bde1d0