### PR TITLE
Add entities router for cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,10 @@ curl http://localhost:8000/v1/events
 curl http://localhost:8000/v1/task_recon
 ```
 
+### 7. Access case entities
+```bash
+curl http://localhost:8000/entities/Case
+curl http://localhost:8000/entities/Case/{CASE_ID}
+```
+
 These endpoints provide a basic demonstration and can be expanded with persistent storage, authentication, additional sensors or a frontend for visualization. Each collection supports standard CRUD operations (create, read, update and delete) for events, cases and tasks.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,9 @@
 from fastapi import FastAPI
-from .routers import events, cases, tasks
+from .routers import events, cases, tasks, entities
 
 app = FastAPI(title="Recon API")
 
 app.include_router(events.router)
 app.include_router(cases.router)
 app.include_router(tasks.router)
+app.include_router(entities.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -18,8 +18,15 @@ class Event(BaseModel):
 class Case(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     title: str
+    status: str = "New"
     location: Location
+    summary: Optional[str] = None
     initial_event_id: str
+    created_date: Optional[str] = None
+    updated_date: Optional[str] = None
+    created_by_id: Optional[str] = None
+    created_by: Optional[str] = None
+    is_sample: bool = False
 
 class TaskRequest(BaseModel):
     case_id: str

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,3 +1,3 @@
-from . import events, cases, tasks
+from . import events, cases, tasks, entities
 
-__all__ = ["events", "cases", "tasks"]
+__all__ = ["events", "cases", "tasks", "entities"]

--- a/backend/app/routers/cases.py
+++ b/backend/app/routers/cases.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException
+from datetime import datetime
 from ..models import Case
 from .events import get_event
 
@@ -10,6 +11,9 @@ cases_db = []
 def create_case(case: Case):
     if not get_event(case.initial_event_id):
         raise HTTPException(status_code=404, detail="initial_event_id not found")
+    now = datetime.utcnow().isoformat() + "Z"
+    case.created_date = now
+    case.updated_date = now
     cases_db.append(case)
     return case
 
@@ -32,6 +36,8 @@ def update_case(case_id: str, case_update: Case):
     if not case:
         raise HTTPException(status_code=404, detail="case not found")
     case_update.id = case_id
+    case_update.created_date = case.created_date
+    case_update.updated_date = datetime.utcnow().isoformat() + "Z"
     idx = cases_db.index(case)
     cases_db[idx] = case_update
     return case_update

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, HTTPException
+from .cases import cases_db, get_case
+from ..models import Case
+
+router = APIRouter(prefix="/entities", tags=["entities"])
+
+@router.get("/Case", response_model=list[Case])
+def list_case_entities():
+    return cases_db
+
+@router.get("/Case/{case_id}", response_model=Case)
+def read_case_entity(case_id: str):
+    case = get_case(case_id)
+    if not case:
+        raise HTTPException(status_code=404, detail="case not found")
+    return case


### PR DESCRIPTION
## Summary
- extend `Case` model with metadata fields
- record timestamps when creating or updating cases
- add `/entities/Case` endpoints and include router
- document how to access case entities in README

## Testing
- `python -m pip install -r backend/requirements.txt`
- `pip install httpx`
- `python -m py_compile $(git ls-files '*.py')`
- manual test with `TestClient` to create and fetch cases


------
https://chatgpt.com/codex/tasks/task_e_688583f7fd28832eb79674f3c7813a03