### PR TITLE
Enable CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ uvicorn backend.app.main:app --reload
 
 The API will be available at `http://localhost:8000` and includes automatic Swagger UI documentation at `http://localhost:8000/docs`.
 
+Cross-origin requests from `http://localhost:8000` and pages served via `file://` are allowed so the included frontend can communicate with the API.
+
 ## Example Endpoints
 
 You can test the API using `curl`, Postman or any HTTP client.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,15 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from .routers import events, cases, tasks, entities
 
 app = FastAPI(title="Recon API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:8000", "file://"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(events.router)
 app.include_router(cases.router)


### PR DESCRIPTION
## Summary
- add CORS middleware to FastAPI
- document allowed origins in README

## Testing
- `pytest -q`
- `python -m uvicorn backend.app.main:app --reload --port 8001` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_6885875d9ecc832e9d7d4bfcc8dbc919