### PR TITLE
Switch case/event times to datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curl -X POST http://localhost:8000/v1/events \
   -d '{
     "source_type": "osint",
     "source_id": "telegram_watchdog",
-    "timestamp": "2025-07-25T10:00:00Z",
+    "timestamp": "2025-07-25T10:00:00Z",  # ISO 8601 datetime
     "location": { "lat": 34.05, "lon": -118.25 },
     "summary": "Unusual troop movement near highway"
   }'
@@ -59,6 +59,7 @@ curl -X POST http://localhost:8000/v1/cases \
     "initial_event_id": "YOUR_EVENT_ID_HERE"
   }'
 ```
+# created_date and updated_date are automatically set by the server
 
 ### 3. Task a recon asset
 ```bash

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional
+from datetime import datetime
 from uuid import uuid4
 
 class Location(BaseModel):
@@ -10,7 +11,7 @@ class Event(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     source_type: str
     source_id: str
-    timestamp: str
+    timestamp: datetime
     location: Location
     summary: str
     media_url: Optional[str] = None
@@ -22,8 +23,8 @@ class Case(BaseModel):
     location: Location
     summary: Optional[str] = None
     initial_event_id: str
-    created_date: Optional[str] = None
-    updated_date: Optional[str] = None
+    created_date: Optional[datetime] = None
+    updated_date: Optional[datetime] = None
     created_by_id: Optional[str] = None
     created_by: Optional[str] = None
     is_sample: bool = False

--- a/backend/app/routers/cases.py
+++ b/backend/app/routers/cases.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from datetime import datetime
+from datetime import datetime, timezone
 from ..models import Case
 from .events import get_event
 
@@ -11,7 +11,7 @@ cases_db = []
 def create_case(case: Case):
     if not get_event(case.initial_event_id):
         raise HTTPException(status_code=404, detail="initial_event_id not found")
-    now = datetime.utcnow().isoformat() + "Z"
+    now = datetime.now(timezone.utc)
     case.created_date = now
     case.updated_date = now
     cases_db.append(case)
@@ -37,7 +37,7 @@ def update_case(case_id: str, case_update: Case):
         raise HTTPException(status_code=404, detail="case not found")
     case_update.id = case_id
     case_update.created_date = case.created_date
-    case_update.updated_date = datetime.utcnow().isoformat() + "Z"
+    case_update.updated_date = datetime.now(timezone.utc)
     idx = cases_db.index(case)
     cases_db[idx] = case_update
     return case_update


### PR DESCRIPTION
## Summary
- use `datetime` in pydantic models
- generate datetimes in the cases router
- adjust README examples for datetime inputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6885875e8064832eb65ad3744337e83c