### PR TITLE
Switch in-memory DBs to dicts

### DIFF
--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -6,7 +6,7 @@ router = APIRouter(prefix="/entities", tags=["entities"])
 
 @router.get("/Case", response_model=list[Case])
 def list_case_entities():
-    return cases_db
+    return list(cases_db.values())
 
 @router.get("/Case/{case_id}", response_model=Case)
 def read_case_entity(case_id: str):

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -3,16 +3,17 @@ from ..models import Event
 
 router = APIRouter(prefix="/v1/events", tags=["events"])
 
-events_db = []
+# Use a simple in-memory dict for storage keyed by event ID
+events_db: dict[str, Event] = {}
 
 @router.post("", response_model=Event)
 def create_event(event: Event):
-    events_db.append(event)
+    events_db[event.id] = event
     return event
 
 @router.get("", response_model=list[Event])
 def list_events():
-    return events_db
+    return list(events_db.values())
 
 @router.get("/{event_id}", response_model=Event)
 def read_event(event_id: str):
@@ -23,24 +24,18 @@ def read_event(event_id: str):
 
 @router.put("/{event_id}", response_model=Event)
 def update_event(event_id: str, event_update: Event):
-    event = get_event(event_id)
-    if not event:
+    if event_id not in events_db:
         raise HTTPException(status_code=404, detail="event not found")
     event_update.id = event_id
-    idx = events_db.index(event)
-    events_db[idx] = event_update
+    events_db[event_id] = event_update
     return event_update
 
 @router.delete("/{event_id}")
 def delete_event(event_id: str):
-    event = get_event(event_id)
+    event = events_db.pop(event_id, None)
     if not event:
         raise HTTPException(status_code=404, detail="event not found")
-    events_db.remove(event)
     return {"detail": "deleted"}
 
-def get_event(event_id: str) -> Event:
-    for e in events_db:
-        if e.id == event_id:
-            return e
-    return None
+def get_event(event_id: str) -> Event | None:
+    return events_db.get(event_id)


### PR DESCRIPTION
## Summary
- store events, cases and tasks in dicts keyed by their IDs
- update CRUD endpoints to use dictionary lookups
- return lists of dictionary values

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6885875f2ca0832eb89ad9e46feb35d1