### PR TITLE
Add enums for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ curl -X POST http://localhost:8000/v1/task_recon \
   }'
 ```
 
+Allowed sensor types are `optical`, `infrared`, and `radar`. Urgency levels can
+be `low`, `medium`, or `high`.
+
 ### 4. View all active cases
 ```bash
 curl http://localhost:8000/v1/cases

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from uuid import uuid4
+from enum import Enum
 
 class Location(BaseModel):
     lat: float
@@ -28,15 +29,27 @@ class Case(BaseModel):
     created_by: Optional[str] = None
     is_sample: bool = False
 
+
+class Urgency(str, Enum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+
+
+class SensorType(str, Enum):
+    optical = "optical"
+    infrared = "infrared"
+    radar = "radar"
+
 class TaskRequest(BaseModel):
     case_id: str
-    sensor_types: List[str]
-    urgency: str
+    sensor_types: List[SensorType]
+    urgency: Urgency
     preferred_assets: List[str] = []
 
 class Task(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     case_id: str
-    sensor_types: List[str]
-    urgency: str
+    sensor_types: List[SensorType]
+    urgency: Urgency
     preferred_assets: List[str] = []


### PR DESCRIPTION
## Summary
- add enumeration classes for Task urgency and allowed sensor types
- reference the enums in Task models
- document the enum values in README

## Testing
- `python -m pip install -r backend/requirements.txt`
- `pytest -q`
- `python -m compileall backend`


------
https://chatgpt.com/codex/tasks/task_e_6885876ab0f0832eb8fed683f340ee40