### PR TITLE
Serve frontend through FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A simple HTML/JavaScript interface is provided in `frontend/` for interacting wi
 Cases API.
 
 1. Start the backend API as described above.
-2. Open `frontend/index.html` in your web browser.
+2. Visit `http://localhost:8000` in your browser.
 
 From the page you can create, edit and delete cases. The frontend expects the
 backend to be available at `http://localhost:8000`.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 from .routers import events, cases, tasks, entities
 
 app = FastAPI(title="Recon API")
@@ -7,3 +9,8 @@ app.include_router(events.router)
 app.include_router(cases.router)
 app.include_router(tasks.router)
 app.include_router(entities.router)
+
+# Serve the simple frontend bundled in the repository. Using an absolute path
+# allows running the application from any working directory.
+frontend_dir = Path(__file__).resolve().parents[2] / "frontend"
+app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")


### PR DESCRIPTION
## Summary
- mount the `frontend/` folder using `StaticFiles`
- update docs to access the frontend at the server root

## Testing
- `python3 -m py_compile backend/app/*.py backend/app/routers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68858769c73c832e93848dfd526ead28