### PR TITLE
Add Dockerfile and Docker instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./backend
+EXPOSE 8000
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ pip install -r backend/requirements.txt
 uvicorn backend.app.main:app --reload
 ```
 
+### Docker
+
+Build the image and run the API without installing Python locally:
+
+```bash
+docker build -t recon-api .
+docker run --rm -p 8000:8000 recon-api
+```
+
 The API will be available at `http://localhost:8000` and includes automatic Swagger UI documentation at `http://localhost:8000/docs`.
 
 ## Example Endpoints


### PR DESCRIPTION
## Summary
- add Dockerfile for running the FastAPI backend
- document how to build and run the container

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68858768c704832ea8aa09e98e6a866f