### PR TITLE
Add case-specific task listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,11 @@ curl http://localhost:8000/v1/events
 curl http://localhost:8000/v1/task_recon
 ```
 
-### 7. Access case entities
+### 7. List tasks for a case
+```bash
+curl http://localhost:8000/v1/task_recon/case/{CASE_ID}
+```
+### 8. Access case entities
 ```bash
 curl http://localhost:8000/entities/Case
 curl http://localhost:8000/entities/Case/{CASE_ID}

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -23,6 +23,14 @@ def create_task(task_req: TaskRequest):
 def list_tasks():
     return tasks_db
 
+
+@router.get("/case/{case_id}", response_model=list[Task])
+def list_tasks_for_case(case_id: str):
+    """Return tasks associated with a particular case."""
+    if not get_case(case_id):
+        raise HTTPException(status_code=404, detail="case not found")
+    return [t for t in tasks_db if t.case_id == case_id]
+
 def get_task(task_id: str) -> Task:
     for t in tasks_db:
         if t.id == task_id:


### PR DESCRIPTION
## Summary
- add endpoint to fetch tasks by case_id
- document task lookup in README

## Testing
- `python -m py_compile backend/app/routers/tasks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885876751bc832eb1748e27e5a3313c