### PR TITLE
Fix preferred_assets defaults

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -46,11 +46,11 @@ class TaskRequest(BaseModel):
     case_id: str
     sensor_types: List[SensorType]
     urgency: Urgency
-    preferred_assets: List[str] = []
+    preferred_assets: List[str] = Field(default_factory=list)
 
 class Task(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     case_id: str
     sensor_types: List[SensorType]
     urgency: Urgency
-    preferred_assets: List[str] = []
+    preferred_assets: List[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- avoid shared mutable default lists for `TaskRequest` and `Task`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885aa93d50c832eb156804c29d40046