### PR TITLE
Fix db imports and add integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend
+COPY frontend ./frontend
 EXPOSE 8000
 CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/routers/cases.py
+++ b/backend/app/routers/cases.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, HTTPException
 from datetime import datetime, timezone
 from ..models import Case
 from .events import get_event
-from .. import memory_db as database
+# Use TinyDB-backed database for persistence
+from .. import database
 
 router = APIRouter(prefix="/v1/cases", tags=["cases"])
 

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, HTTPException
 from .cases import get_case
 from ..models import Case
-from .. import memory_db as database
+# Use TinyDB-backed database for persistence
+from .. import database
 
 router = APIRouter(prefix="/entities", tags=["entities"])
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from ..models import Event
-from .. import memory_db as database
+# Use TinyDB-backed database for persistence
+from .. import database
 
 router = APIRouter(prefix="/v1/events", tags=["events"])
 

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, HTTPException
 from ..models import Task, TaskRequest
 from .cases import get_case
-from .. import memory_db as database
+# Use TinyDB-backed database for persistence
+from .. import database
 
 router = APIRouter(prefix="/v1/task_recon", tags=["tasks"])
 

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 from backend.app.main import app
-from backend.app import memory_db as database
+from backend.app import database
 
 client = TestClient(app)
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,46 @@
+import pytest
+from fastapi.testclient import TestClient
+from backend.app.main import app
+from backend.app import database
+
+client = TestClient(app)
+
+@pytest.fixture(autouse=True)
+def clear_db():
+    database.clear_db()
+    yield
+    database.clear_db()
+
+def create_event():
+    payload = {
+        "source_type": "osint",
+        "source_id": "src",
+        "timestamp": "2025-01-01T00:00:00Z",
+        "location": {"lat": 0, "lon": 0},
+        "summary": "event",
+    }
+    resp = client.post("/v1/events", json=payload)
+    return resp.json()["id"]
+
+
+def create_case(event_id):
+    payload = {
+        "title": "case",
+        "location": {"lat": 0, "lon": 0},
+        "initial_event_id": event_id,
+    }
+    resp = client.post("/v1/cases", json=payload)
+    return resp.json()["id"]
+
+
+def test_entities_list_and_get():
+    event_id = create_event()
+    case_id = create_case(event_id)
+
+    resp = client.get("/entities/Case")
+    assert resp.status_code == 200
+    assert any(c["id"] == case_id for c in resp.json())
+
+    resp = client.get(f"/entities/Case/{case_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == case_id

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 from backend.app.main import app
-from backend.app import memory_db as database
+from backend.app import database
 
 client = TestClient(app)
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+def test_root_serves_index():
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert '<!DOCTYPE html>' in resp.text

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 from backend.app.main import app
-from backend.app import memory_db as database
+from backend.app import database
 
 client = TestClient(app)
 
@@ -72,3 +72,15 @@ def test_task_crud():
 
     resp = client.get(f"/v1/task_recon/{task_id}")
     assert resp.status_code == 404
+
+def test_list_tasks_for_case():
+    event_id = create_event()
+    case_id = create_case(event_id)
+    payload = create_task_payload(case_id)
+    # create task
+    task_id = client.post("/v1/task_recon", json=payload).json()["id"]
+
+    resp = client.get(f"/v1/task_recon/case/{case_id}")
+    assert resp.status_code == 200
+    ids = [t["id"] for t in resp.json()]
+    assert task_id in ids


### PR DESCRIPTION
## Summary
- serve frontend assets from Docker image
- use TinyDB-backed `database` module in routers
- add API tests for entities, root page, and tasks by case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885adc0f988832ea074104d09ee935c